### PR TITLE
Fix quiz freeze on questions with special characters by using dataset answer for button matching

### DIFF
--- a/assets/js/script.js
+++ b/assets/js/script.js
@@ -178,7 +178,7 @@ function answerClickHandling(event) {
   let selectedAnswer = event.target.dataset.answer;
   const correctAnswer = rearranged[currentQuestionNumber].correct_answer;
   const correctButton = answerButtonsRef.find(
-    (button) => button.innerText === correctAnswer
+    (button) => button.dataset.answer === correctAnswer
   );
 
   /**
@@ -206,7 +206,7 @@ function noAnswer() {
   answerButtonsRef.forEach((button) => (button.disabled = true));
   const correctAnswer = rearranged[currentQuestionNumber].correct_answer;
   const correctButton = answerButtonsRef.find(
-    (button) => button.innerText === correctAnswer
+    (button) => button.dataset.answer === correctAnswer
   );
   correctButton.style.backgroundColor = "green";
   incorrectScore++;


### PR DESCRIPTION
## Summary
This PR fixes a bug where the quiz would freeze on certain questions containing special characters (HTML entities).

## Changes
- Updated `answerClickHandling()` and `noAnswer()` functions to use `dataset.answer` instead of `innerText` for finding the correct answer button.
- This prevents errors when HTML entities render differently as `innerText`, causing `correctButton` to be `undefined` and throwing a JavaScript error.

## Testing
- Verified that questions with special characters now work without freezing.
- Other questions continue to function normally.